### PR TITLE
echidna: replace multi-abi with allContracts in configs

### DIFF
--- a/naivereceiver.yaml
+++ b/naivereceiver.yaml
@@ -2,3 +2,5 @@
 balanceContract: 10000000000000000000000
 # Allow for multi-abi use
 multi-abi: true
+# multi-abi was renamed in echidna >= 2.1
+allContracts: true

--- a/unstoppable.yaml
+++ b/unstoppable.yaml
@@ -6,3 +6,5 @@ deployer: '0x30000'
 sender: ['0x30000']
 # Allow for multi-abi use
 multi-abi: true
+# multi-abi was renamed in echidna >= 2.1
+allContracts: true


### PR DESCRIPTION
Echidna renamed its `multi-abi` option to `allContracts` in commit ff312a6 ("Rename multi-abi to allContracts"). This adds the new option to the test configuration to keep CI passing, while maintaining references to the currently available option to work on both releases.